### PR TITLE
Add net7.0 and net8.0 as target frameworks to support .net 7 and .net 8

### DIFF
--- a/src/DotNetToolsOutdated/DotNetToolsOutdated.csproj
+++ b/src/DotNetToolsOutdated/DotNetToolsOutdated.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <AssemblyName>dotnet-tools-outdated</AssemblyName>
@@ -16,7 +16,7 @@
     <PackageProjectUrl>https://github.com/rychlym/dotnet-tools-outdated</PackageProjectUrl>
     <RepositoryUrl>https://github.com/rychlym/dotnet-tools-outdated</RepositoryUrl>
     <PackageTags>dotnet core,tools, outdated</PackageTags>
-    <Version>0.6.0</Version>
+    <Version>0.6.1</Version>
     <Authors>Mojmir Rychly</Authors>
     <Company />
     <Product />

--- a/src/DotNetToolsOutdated/DotNetToolsOutdated.csproj
+++ b/src/DotNetToolsOutdated/DotNetToolsOutdated.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <AssemblyName>dotnet-tools-outdated</AssemblyName>


### PR DESCRIPTION
Works on my machine. These are the steps I took to test locally

```bash
# move into main project folder
cd src/DotNetToolsOutdated

# clean and build the project
dotnet clean
dotnet restore
dotnet build

# remove any old nupkg files
rm -rf nupkg

# package the dotnet tool
dotnet pack -c release -o nupkg

# uninstall any version you currently have installed
dotnet tool uninstall -g dotnet-tools-outdated  

# install the version we have just built and packaged
dotnet tool install -g --add-source /Users/solrevdev/Dropbox/Projects/github/dotnet-tools-outdated/src/DotNetToolsOutdated/nupkg dotnet-tools-outdated

# refresh your terminal
exec zsh -l # aka refreshenv an alias on my machine

# run the tool
dotnet-tools-outdated
```